### PR TITLE
Fix to transition radius

### DIFF
--- a/+models/double_polytrope.m
+++ b/+models/double_polytrope.m
@@ -25,8 +25,10 @@ function cmp = double_polytrope(N, x, lamstrat, forcematch)
 narginchk(2,4)
 if ((nargin == 2) || isempty(lamstrat)), lamstrat = [2/3, 1/2]; end
 if ((nargin < 4) || isempty(forcematch)), forcematch = false; end
+validateattributes(N, {'numeric'}, {'positive', 'integer'}, '', 'N', 1)
+validateattributes(x, {'numeric'}, {'vector', 'numel', 5, 'nonnegative'}, 2)
 validateattributes(lamstrat, {'numeric'}, {'vector', 'numel', 2, '>', 0, '<', 1})
-validateattributes(forcematch, {'logical'}, {'scalar'})
+validateattributes(forcematch, {'logical'}, {'scalar'}, '', 'forcematch', 4)
 assert(x(5)>0 && x(5)<1, 'Transition (normalized) radius must be in (0,1).')
 
 cmp = CMSPlanet(N);

--- a/+models/double_polytrope.m
+++ b/+models/double_polytrope.m
@@ -1,14 +1,13 @@
-function cmp = double_polytrope(N, x, lamstrat)
+function cmp = double_polytrope(N, x, lamstrat, forcematch)
 %DOUBLE_POLYTROPE Model planet approximated by two polytropes.
 %    DOUBLE_POLYTROPE(N, x) returns an N-layer CMSPlanet object with two
 %    barotropes.Polytrope eos objects. First polytrope defined by constant x(1)
-%    and index x(2) is applied to layers 2:tind. Second polytrope defined by
-%    constant x(3) and index x(4) is applied to layers tind+1:N. Transition is at
-%    layer tind+1, the first layer with (ai/a0)<=x(5). Layer 1 is assigned a zero
-%    density barotropes.ConstDensity eos and is approximately half the width of
-%    the layers below. The layer spacing is designed to minimize discretization
-%    error by concentrating 2/3 of the available layers in the top 0.5 of the
-%    planet.
+%    and index x(2) is applied to layers 2:tind-1. Second polytrope defined by
+%    constant x(3) and index x(4) is applied to layers tind:N. Transition is at
+%    layer tind, the layer with (ai/a0) nearest to x(5). Layer 1 is assigned a
+%    zero density barotropes.ConstDensity eos and is approximately half the width
+%    of the layers below. The default layer spacing concentrates 2/3 of the
+%    available layers in the top 0.5 of the planet.
 %
 %    DOUBLE_POLYTROPE(N, x, lamstrat) uses the 2-element vector lamstrat to
 %    specify the layer spacing strategy. Approximately lamstrat(1) of available
@@ -17,11 +16,18 @@ function cmp = double_polytrope(N, x, lamstrat)
 %    planet, leaving about N/4 layers to fill the bottom 80%. Passing [r, r] gives
 %    approximately equal spacing throughout the planet. (Approximately because a
 %    single half-width layer of zero density is always reserved for the surface.)
+%    Use [] (empty array) for default values.
+%
+%    DOUBLE_POLYTROPE(..., forcematch) if forcematch=true forces the normalized
+%    radius of the transition layer to exactly match x(5). This is applied after
+%    the lambda spacing strategy.
 
-narginchk(2,3)
-if nargin == 2, lamstrat = [2/3, 1/2]; end
+narginchk(2,4)
+if ((nargin == 2) || isempty(lamstrat)), lamstrat = [2/3, 1/2]; end
+if ((nargin < 4) || isempty(forcematch)), forcematch = false; end
 validateattributes(lamstrat, {'numeric'}, {'vector', 'numel', 2, '>', 0, '<', 1})
-assert(x(5)>0 && x(5)<1, 'The transition must be 0<R<1.')
+validateattributes(forcematch, {'logical'}, {'scalar'})
+assert(x(5)>0 && x(5)<1, 'Transition (normalized) radius must be in (0,1).')
 
 cmp = CMSPlanet(N);
 
@@ -31,13 +37,14 @@ dl1 = lamstrat(2)/(n1 - 1);
 dl2 = (1 - lamstrat(2))/(n2 + 1);
 lam1 = linspace(1 - dl1/2, (1 - lamstrat(2)), n1);
 lam2 = linspace((1 - lamstrat(2)) - dl2, dl2, n2);
-mylambdas = [1, lam1, lam2]';
+lambdas = [1, lam1, lam2]';
 
-% Replace lambda_tind to match the transition
-[~, tind] = min(abs(mylambdas-x(5)));
-assert(tind > 2, 'The transition is too close to the surface and the first polytrope has zero layers.')
-mylambdas(tind) = x(5);
-cmp.cms.lambdas = mylambdas;
+[~, tind] = min(abs(lambdas-x(5)));
+assert(tind > 2,...
+    'Transition too close to surface; first polytrope has zero layers.')
+if forcematch, lambdas(tind) = x(5); end
+
+cmp.cms.lambdas = lambdas;
 
 eos0 = barotropes.ConstDensity(0);
 eos1 = barotropes.Polytrope(x(1), x(2));

--- a/+models/double_polytrope.m
+++ b/+models/double_polytrope.m
@@ -21,7 +21,7 @@ function cmp = double_polytrope(N, x, lamstrat)
 narginchk(2,3)
 if nargin == 2, lamstrat = [2/3, 1/2]; end
 validateattributes(lamstrat, {'numeric'}, {'vector', 'numel', 2, '>', 0, '<', 1})
-assert(x(5)>0 && x(5)<1, 'The transition must be 0 < R_trans < 1.')
+assert(x(5)>0 && x(5)<1, 'The transition must be 0<R<1.')
 
 cmp = CMSPlanet(N);
 
@@ -33,7 +33,7 @@ lam1 = linspace(1 - dl1/2, (1 - lamstrat(2)), n1);
 lam2 = linspace((1 - lamstrat(2)) - dl2, dl2, n2);
 mylambdas = [1, lam1, lam2]';
 
-% Replace lambda_tind as to match the transition
+% Replace lambda_tind to match the transition
 [~, tind] = min(abs(mylambdas-x(5)));
 assert(tind > 2, 'The transition is too close to the surface and the first polytrope has zero layers.')
 mylambdas(tind) = x(5);

--- a/+models/double_polytrope_w_core.m
+++ b/+models/double_polytrope_w_core.m
@@ -31,8 +31,10 @@ function cmp = double_polytrope_w_core(N, x, lamstrat, forcematch)
 narginchk(2,4)
 if ((nargin == 2) || isempty(lamstrat)), lamstrat = [2/3, 1/2]; end
 if ((nargin < 4) || isempty(forcematch)), forcematch = false; end
+validateattributes(N, {'numeric'}, {'positive', 'integer'}, '', 'N', 1)
+validateattributes(x, {'numeric'}, {'vector', 'numel', 7, 'nonnegative'}, 2)
 validateattributes(lamstrat, {'numeric'}, {'vector', 'numel', 2, '>', 0, '<', 1})
-validateattributes(forcematch, {'logical'}, {'scalar'})
+validateattributes(forcematch, {'logical'}, {'scalar'}, '', 'forcematch', 4)
 assert(x(5) > 0 && x(5) < 1, 'Transition (normalized) radius must be in (0,1).')
 assert(x(7) > 0 && x(7) < 1, 'The core must have a normalized radius in (0,1).')
 assert(x(7) < x(5), 'Core radius must be smaller than transition radius.')

--- a/+models/double_polytrope_w_core.m
+++ b/+models/double_polytrope_w_core.m
@@ -2,15 +2,14 @@ function cmp = double_polytrope_w_core(N, x, lamstrat, forcematch)
 %DOUBLE_POLYTROPE_W_CORE Two polytrope and core model planet.
 %    DOUBLE_POLYTROPE_W_CORE(N, x) returns an N-layer CMSPlanet object with two
 %    barotropes.Polytrope eos objects. First polytrope defined by constant x(1)
-%    and index x(2) is applied to layers 2:tind. Second polytrope defined by
-%    constant x(3) and index x(4) is applied to layers tind+1:N-1. Transition is
-%    at layer tind+1, the first layer with (ai/a0)<=x(5). Layer N is assigned a
+%    and index x(2) is applied to layers 2:tind-1. Second polytrope defined by
+%    constant x(3) and index x(4) is applied to layers tind:N-1. Transition is at
+%    layer tind, the layer with (ai/a0) nearest to x(5). Layer N is assigned a
 %    barotropes.ConstDensity eos wirh rho0=x(6) and given a normalized equatorial
 %    radius equal to x(7). Layer 1 is assigned a zero density
 %    barotropes.ConstDensity eos and is approximately half the width of the layers
-%    below. The layer spacing is designed to minimize discretization error by
-%    concentrating 2/3 of the available layers in the top 0.5 of the planet (see
-%    Hubbard & Militzer, 2016). However if x(7)>0.2 then layers are equally spaced
+%    below. The default layer spacing concentrates 2/3 of the available layers in
+%    the top 0.5 of the planet. However if x(7)>0.2 then layers are equally spaced
 %    above x(7).
 %
 %    DOUBLE_POLYTROPE_W_CORE(N, x, lamstrat) uses the 2-element vector lamstrat to
@@ -22,26 +21,27 @@ function cmp = double_polytrope_w_core(N, x, lamstrat, forcematch)
 %    single half-width layer of zero density is always reserved for the surface.)
 %    However if x(7)>0.2 or if x(7)>(1-lamstrat(2)) then we revert to equally
 %    spaced layers again. Note that when x(7) is close to (1-lamstrat(2)) you
-%    might be better of using equal spacing!
+%    might be better of using equal spacing! Use [] (empty array) for default
+%    values.
 %
-%    DOUBLE_POLYTROPE(..., forcematch) if forcematch=true forces the normalized
-%    radius of the transition layer to exactly match x(5). This is applied after
-%    the lambda spacing strategy.
+%    DOUBLE_POLYTROPE_W_CORE(..., forcematch) if forcematch=true forces the
+%    normalized radius of the transition layer to exactly match x(5). This is
+%    applied after the lambda spacing strategy.
 
-narginchk(2,3)
+narginchk(2,4)
 if ((nargin == 2) || isempty(lamstrat)), lamstrat = [2/3, 1/2]; end
 if ((nargin < 4) || isempty(forcematch)), forcematch = false; end
 validateattributes(lamstrat, {'numeric'}, {'vector', 'numel', 2, '>', 0, '<', 1})
 validateattributes(forcematch, {'logical'}, {'scalar'})
-assert(x(5)>0 && x(5)<1, 'The transition must be 0<R<1.')
-assert(x(7)>0 && x(7)<1, 'The core must have a radius 0<R<1.')
-assert(x(7)<x(5), 'The core radius must be smaller than the transition radius.')
+assert(x(5) > 0 && x(5) < 1, 'Transition (normalized) radius must be in (0,1).')
+assert(x(7) > 0 && x(7) < 1, 'The core must have a normalized radius in (0,1).')
+assert(x(7) < x(5), 'Core radius must be smaller than transition radius.')
 
 cmp = CMSPlanet(N);
 
 if (x(7) > 0.2) || (x(7) >= (1 - lamstrat(2)))
     dl = (1 - x(7))/N;
-    mylambdas = [1, linspace(1 - dl/2, x(7), N - 1)]';
+    lambdas = [1, linspace(1 - dl/2, x(7), N - 1)]';
 else
     n1 = fix(lamstrat(1)*(N - 1));
     n2 = N - n1 - 1;
@@ -49,17 +49,17 @@ else
     dl2 = (1 - lamstrat(2) - x(7))/n2;
     lam1 = linspace(1 - dl1/2, (1 - lamstrat(2)), n1);
     lam2 = linspace((1 - lamstrat(2)) - dl2, x(7), n2);
-    mylambdas = [1, lam1, lam2]';
+    lambdas = [1, lam1, lam2]';
 end
 
-% Replace lambda_tind to match the transition
-[~, tind] = min(abs(mylambdas-x(5)));
+[~, tind] = min(abs(lambdas-x(5)));
 assert(tind > 2,...
-    'The transition is too close to the surface, the first polytrope has zero layers.')
+    'Transition too close to surface; first polytrope has zero layers.')
 assert(tind < N,...
-    'The transition is too close to the core, the second polytrope has zero layers.')
-if forcematch, mylambdas(tind) = x(5); end
-cmp.cms.lambdas = mylambdas;
+    'Transition too close to core; second polytrope has zero layers.')
+if forcematch, lambdas(tind) = x(5); end
+
+cmp.cms.lambdas = lambdas;
 
 eos0 = barotropes.ConstDensity(0);
 eos1 = barotropes.Polytrope(x(1), x(2));

--- a/+models/single_polytrope.m
+++ b/+models/single_polytrope.m
@@ -15,7 +15,9 @@ function cmp = single_polytrope(N, x, lamstrat)
 %    single half-width layer of zero density is always reserved for the surface.)
 
 narginchk(2,3)
-if nargin == 2, lamstrat = [2/3, 1/2]; end
+if ((nargin == 2) || isempty(lamstrat)), lamstrat = [2/3, 1/2]; end
+validateattributes(N, {'numeric'}, {'positive', 'integer'}, '', 'N', 1)
+validateattributes(x, {'numeric'}, {'vector', 'numel', 2, 'nonnegative'}, 2)
 validateattributes(lamstrat, {'numeric'}, {'vector', 'numel', 2, '>', 0, '<', 1})
 
 cmp = CMSPlanet(N);

--- a/+models/single_polytrope.m
+++ b/+models/single_polytrope.m
@@ -3,9 +3,8 @@ function cmp = single_polytrope(N, x, lamstrat)
 %    SINGLE_POLYTROPE(N, x) returns an N-layer CMSPlanet object with a
 %    barotropes.Polytrope with constant x(1) and index x(2) assigned to layers
 %    2:N. Layer 1 is assigned a zero density barotropes.ConstDensity eos and is
-%    approximately half the width of the layers below. The layer spacing is
-%    designed to minimize discretization error by concentrating 2/3 of the
-%    available layers in the top 0.5 of the planet.
+%    approximately half the width of the layers below. The default layer spacing
+%    concentrates 2/3 of the available layers in the top 0.5 of the planet.
 %
 %    SINGLE_POLYTROPE(N, x, lamstrat) uses the 2-element vector lamstrat to
 %    specify the layer spacing strategy. Approximately lamstrat(1) of available

--- a/+models/single_polytrope_w_core.m
+++ b/+models/single_polytrope_w_core.m
@@ -21,7 +21,9 @@ function cmp = single_polytrope_w_core(N, x, lamstrat)
 %    might be better off using equal spacing!
 
 narginchk(2,3)
-if nargin == 2, lamstrat = [2/3, 1/2]; end
+if ((nargin == 2) || isempty(lamstrat)), lamstrat = [2/3, 1/2]; end
+validateattributes(N, {'numeric'}, {'positive', 'integer'}, '', 'N', 1)
+validateattributes(x, {'numeric'}, {'vector', 'numel', 4, 'nonnegative'}, 2)
 validateattributes(lamstrat, {'numeric'}, {'vector', 'numel', 2, '>', 0, '<', 1})
 assert(x(4) > 0 && x(4) < 1, 'The core must have a normalized radius in (0,1).')
 

--- a/+models/single_polytrope_w_core.m
+++ b/+models/single_polytrope_w_core.m
@@ -1,14 +1,13 @@
 function cmp = single_polytrope_w_core(N, x, lamstrat)
 %SINGLE_POLYTROPE_W_CORE Polytrope-and-core planet.
-%    SINGLE_POLYTROPE_W_CORE(N, x) returns an N-layer CMSPlanet object with
-%    a barotropes.Polytrope with constant x(1) and index x(2) assigned to layers
+%    SINGLE_POLYTROPE_W_CORE(N, x) returns an N-layer CMSPlanet object with a
+%    barotropes.Polytrope with constant x(1) and index x(2) assigned to layers
 %    2:N-1 and a barotropes.ConstDensity eos with rho0=x(3) assigned to layer N
-%    which has a normalized equatorial radius equal to x(4). Layer 1 is assigned
-%    a zero density barotropes.ConstDensity eos and is approximately half the
-%    width of the layers below. The layer spacing is designed to minimize
-%    discretization error by concentrating 2/3 of the available layers in the
-%    top 0.5 of the planet (see Hubbard & Militzer, 2016). However if x(4)>0.2
-%    then layers are equally spaced above x(4).
+%    which has a normalized equatorial radius equal to x(4). Layer 1 is assigned a
+%    zero density barotropes.ConstDensity eos and is approximately half the width
+%    of the layers below. The default layer spacing concentrates 2/3 of the
+%    available layers in the top 0.5 of the planet. However if x(4)>0.2 then
+%    layers are equally spaced above x(4).
 %
 %    SINGLE_POLYTROPE_W_CORE(N, x, lamstrat) uses the 2-element vector lamstrat to
 %    specify the layer spacing strategy. Approximately lamstrat(1) of available
@@ -19,12 +18,12 @@ function cmp = single_polytrope_w_core(N, x, lamstrat)
 %    single half-width layer of zero density is always reserved for the surface.)
 %    However if x(4)>0.2 or if x(4)>(1-lamstrat(2)) then we revert to equally
 %    spaced layers again. Note that when x(4) is close to (1-lamstrat(2)) you
-%    might be better of using equal spacing!
+%    might be better off using equal spacing!
 
 narginchk(2,3)
 if nargin == 2, lamstrat = [2/3, 1/2]; end
 validateattributes(lamstrat, {'numeric'}, {'vector', 'numel', 2, '>', 0, '<', 1})
-assert(x(4)>0 && x(4)<1, 'The core must have a radius 0<R<1.')
+assert(x(4) > 0 && x(4) < 1, 'The core must have a normalized radius in (0,1).')
 
 cmp = CMSPlanet(N);
 

--- a/+models/single_polytrope_w_core.m
+++ b/+models/single_polytrope_w_core.m
@@ -24,7 +24,7 @@ function cmp = single_polytrope_w_core(N, x, lamstrat)
 narginchk(2,3)
 if nargin == 2, lamstrat = [2/3, 1/2]; end
 validateattributes(lamstrat, {'numeric'}, {'vector', 'numel', 2, '>', 0, '<', 1})
-assert(x(4) >0 && x(4)<1, 'The core must have a radius 0 < R_core < 1.')
+assert(x(4)>0 && x(4)<1, 'The core must have a radius 0<R<1.')
 
 cmp = CMSPlanet(N);
 

--- a/+models/single_polytrope_w_core.m
+++ b/+models/single_polytrope_w_core.m
@@ -24,7 +24,7 @@ function cmp = single_polytrope_w_core(N, x, lamstrat)
 narginchk(2,3)
 if nargin == 2, lamstrat = [2/3, 1/2]; end
 validateattributes(lamstrat, {'numeric'}, {'vector', 'numel', 2, '>', 0, '<', 1})
-if x(4) <= 0, x(4) = eps; end
+assert(x(4) >0 && x(4)<1, 'The core must have a radius 0 < R_core < 1.')
 
 cmp = CMSPlanet(N);
 

--- a/+models/triple_polytrope.m
+++ b/+models/triple_polytrope.m
@@ -2,16 +2,15 @@ function cmp = triple_polytrope(N, x, lamstrat, forcematch)
 %TRIPLE_POLYTROPE Model planet approximated by three polytropes.
 %    TRIPLE_POLYTROPE(N, x) returns an N-layer CMSPlanet object with three
 %    barotropes.Polytrope eos objects. First polytrope defined by constant x(1)
-%    and index x(2) is applied to layers 2:tind. Second polytrope defined by
-%    constant x(3) and index x(4) is applied to layers tind+1:cind. Third
+%    and index x(2) is applied to layers 2:tind-1. Second polytrope defined by
+%    constant x(3) and index x(4) is applied to layers tind:cind-1. Third
 %    polytrope defined by constant x(5) and index x(6) is applied to layers
-%    cind+1:N. Transition from first to second polytrope is at layer tind+1, the
-%    first layer with (ai/a0)<=x(7). Transition from second to third polytrope is
-%    at layer cind+1, the first layer with (ai/a0)<=x(8). Layer 1 is assigned a
-%    zero density barotropes.ConstDensity eos and is approximately half the width
-%    of the layers below. The layer spacing is designed to minimize discretization
-%    error by concentrating 2/3 of the available layers in the top 0.5 of the
-%    planet (see Hubbard & Militzer, 2016).
+%    cind:N. Transition from first to second polytrope is at layer tind, the layer
+%    with (ai/a0) nearest x(7). Transition from second to third polytrope is at
+%    layer cind, the layer with (ai/a0) nearest x(8). Layer 1 is assigned a zero
+%    density barotropes.ConstDensity eos and is approximately half the width of
+%    the layers below. The default layer spacing concentrates 2/3 of the available
+%    layers in the top 0.5 of the planet.
 %
 %    TRIPLE_POLYTROPE(N, x, lamstrat) uses the 2-element vector lamstrat to
 %    specify the layer spacing strategy. Approximately lamstrat(1) of available
@@ -20,19 +19,20 @@ function cmp = triple_polytrope(N, x, lamstrat, forcematch)
 %    planet, leaving about N/4 layers to fill the bottom 80%. Passing [r, r] gives
 %    approximately equal spacing throughout the planet. (Approximately because a
 %    single half-width layer of zero density is always reserved for the surface.)
+%    Use [] (empty array) for default values.
 %
-%    DOUBLE_POLYTROPE(..., forcematch) if forcematch=true forces the normalized
-%    radius of the transition layers to exactly match x(7) and x(8). This is
+%    TRIPLE_POLYTROPE(..., forcematch) if forcematch=true forces the normalized
+%    radii of the transition layers to exactly match x(7) and x(8). This is
 %    applied after the lambda spacing strategy.
 
-narginchk(2,3)
+narginchk(2,4)
 if ((nargin == 2) || isempty(lamstrat)), lamstrat = [2/3, 1/2]; end
 if ((nargin < 4) || isempty(forcematch)), forcematch = false; end
 validateattributes(lamstrat, {'numeric'}, {'vector', 'numel', 2, '>', 0, '<', 1})
 validateattributes(forcematch, {'logical'}, {'scalar'})
-assert(x(7)>0 && x(7)<1, 'The first transition must be 0<R<1.')
-assert(x(8)>0 && x(8)<1, 'The second transition must be 0<R<1.')
-assert(x(8)<x(7), 'The second transition must be before the first transition.')
+assert(x(7) > 0 && x(7) < 1, 'First transition radius must be in (0,1).')
+assert(x(8) > 0 && x(8) < 1, 'Second transition radius must be in (0,1).')
+assert(x(8) < x(7), 'Second transition must come before first transition.')
 
 cmp = CMSPlanet(N);
 
@@ -42,25 +42,23 @@ dl1 = lamstrat(2)/(n1 - 1);
 dl2 = (1 - lamstrat(2))/(n2 + 1);
 lam1 = linspace(1 - dl1/2, (1 - lamstrat(2)), n1);
 lam2 = linspace((1 - lamstrat(2)) - dl2, dl2, n2);
-mylambdas = [1, lam1, lam2]';
+lambdas = [1, lam1, lam2]';
+
+[~, tind] = min(abs(lambdas-x(7)));
+assert(tind > 2,...
+    'First transition too close to surface; first polytrope has zero layers.')
+[~, cind] = min(abs(lambdas-x(8)));
+assert(cind > tind,...
+    'Transitions are too close together; second polytrope has zero layers.')
+
+if forcematch, lambdas(tind) = x(7); end
+if forcematch, lambdas(cind) = x(8); end
+cmp.cms.lambdas = lambdas;
 
 eos0 = barotropes.ConstDensity(0);
 eos1 = barotropes.Polytrope(x(1), x(2));
 eos2 = barotropes.Polytrope(x(3), x(4));
 eos3 = barotropes.Polytrope(x(5), x(6));
-
-% Replace lambda_tind to match the transition
-[~, tind] = min(abs(mylambdas-x(7)));
-assert(tind > 2,...
-    'The first transition is too close to the surface, the first polytrope has zero layers.')
-if forcematch, mylambdas(tind) = x(7); end
-
-% Replace lambda_cind to match the transition
-[~, cind] = min(abs(mylambdas-x(8)));
-assert(cind > tind,...
-    'The transitions are too close each other, the second polytrope has zero layers.')
-if forcematch, mylambdas(cind) = x(8); end
-cmp.cms.lambdas = mylambdas;
 
 cmp.eos = [eos0;...
     repmat(eos1, tind - 2, 1);...

--- a/+models/triple_polytrope.m
+++ b/+models/triple_polytrope.m
@@ -28,8 +28,10 @@ function cmp = triple_polytrope(N, x, lamstrat, forcematch)
 narginchk(2,4)
 if ((nargin == 2) || isempty(lamstrat)), lamstrat = [2/3, 1/2]; end
 if ((nargin < 4) || isempty(forcematch)), forcematch = false; end
+validateattributes(N, {'numeric'}, {'positive', 'integer'}, '', 'N', 1)
+validateattributes(x, {'numeric'}, {'vector', 'numel', 8, 'nonnegative'}, 2)
 validateattributes(lamstrat, {'numeric'}, {'vector', 'numel', 2, '>', 0, '<', 1})
-validateattributes(forcematch, {'logical'}, {'scalar'})
+validateattributes(forcematch, {'logical'}, {'scalar'}, '', 'forcematch', 4)
 assert(x(7) > 0 && x(7) < 1, 'First transition radius must be in (0,1).')
 assert(x(8) > 0 && x(8) < 1, 'Second transition radius must be in (0,1).')
 assert(x(8) < x(7), 'Second transition must come before first transition.')


### PR DESCRIPTION
The models:
+single_polytrope_w_core.m
+double_polytrope.m
+double_polytrope_w_core.m
+triple_polytrope.m
have been modified to let one of the lambdas to exactly match the input transition radius. Some checks have been added to ensure the resulting model have at least one layer (i.e., no degenerate models allowed) per polytrope.